### PR TITLE
feat: export.transform event with ExportFile transfer helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /composer.lock
+/.phpunit.result.cache

--- a/assets/manifest.xsd
+++ b/assets/manifest.xsd
@@ -63,6 +63,17 @@
                                     </xs:sequence>
                                 </xs:complexType>
                             </xs:element>
+                            <xs:element name="export-transform">
+                                <xs:complexType>
+                                    <xs:attribute name="type" use="required">
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="pohoda-invoice"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
                         </xs:choice>
                     </xs:complexType>
                 </xs:element>

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,11 @@
             "Simplia\\Integration\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Simplia\\Integration\\Tests\\": "tests/"
+        }
+    },
     "authors": [
         {
             "name": "Petr Soukup",
@@ -38,6 +43,7 @@
         }
     },
     "require-dev": {
-        "phpstan/phpstan": "^2.1"
+        "phpstan/phpstan": "^2.1",
+        "phpunit/phpunit": "^9.6"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Event/EventDecoder.php
+++ b/src/Event/EventDecoder.php
@@ -2,6 +2,7 @@
 
 namespace Simplia\Integration\Event;
 
+use Simplia\Integration\Event\Export\ExportTransformEvent;
 use Simplia\Integration\Event\Frontend\FrontendCallContext;
 use Simplia\Integration\Event\Frontend\FrontendCallEvent;
 use Simplia\Integration\Event\Order\AdminBatchOrdersEvent;
@@ -47,6 +48,13 @@ class EventDecoder {
                 return new FrontendCallEvent(
                     $input['data'] ?? [],
                     FrontendCallContext::fromArray($input['context'] ?? []),
+                );
+            case 'export.transform' :
+                return new ExportTransformEvent(
+                    $input['target'],
+                    $input['source'],
+                    $input['destination'],
+                    $input['context'] ?? [],
                 );
         }
 

--- a/src/Event/Export/ExportFile.php
+++ b/src/Event/Export/ExportFile.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Simplia\Integration\Event\Export;
+
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Handles the transfer of an export.transform payload: downloads the gzipped
+ * source from a presigned URL, exposes it as a plain local file, and uploads
+ * the transformed result back to a presigned destination URL.
+ */
+class ExportFile {
+    private array $source;
+    private array $destination;
+    private ?HttpClientInterface $client;
+
+    public function __construct(array $source, array $destination, ?HttpClientInterface $client = null) {
+        $this->source = $source;
+        $this->destination = $destination;
+        $this->client = $client;
+    }
+
+    public function setHttpClient(HttpClientInterface $client): void {
+        $this->client = $client;
+    }
+
+    private function getClient(): HttpClientInterface {
+        return $this->client ??= HttpClient::create(['timeout' => 5 * 60]);
+    }
+
+    /**
+     * Downloads the source export and returns the path of a local, decompressed temporary file.
+     */
+    public function download(): string {
+        $compressedPath = $this->downloadRaw();
+        $path = $this->createTempFile('export');
+        $in = gzopen($compressedPath, 'rb');
+        $out = fopen($path, 'wb');
+        while (!gzeof($in)) {
+            fwrite($out, gzread($in, 512 * 1024));
+        }
+        gzclose($in);
+        fclose($out);
+        unlink($compressedPath);
+
+        return $path;
+    }
+
+    /**
+     * Downloads the source export without decompressing it (still gzipped). For very large files.
+     */
+    public function downloadRaw(): string {
+        if (($this->source['encoding'] ?? null) !== 'gzip') {
+            throw new \RuntimeException('Unsupported source encoding');
+        }
+        $client = $this->getClient();
+        $response = $client->request('GET', $this->source['url']);
+        $path = $this->createTempFile('export-gz');
+        $out = fopen($path, 'wb');
+        foreach ($client->stream($response) as $chunk) {
+            fwrite($out, $chunk->getContent());
+        }
+        fclose($out);
+
+        return $path;
+    }
+
+    public function getContent(): string {
+        $path = $this->download();
+        $content = file_get_contents($path);
+        unlink($path);
+
+        return $content;
+    }
+
+    /**
+     * Gzips the given local file and uploads it as the transformed result.
+     */
+    public function upload(string $path): void {
+        $this->uploadContent(file_get_contents($path));
+    }
+
+    public function uploadContent(string $content): void {
+        $this->uploadBody(gzencode($content, 6));
+    }
+
+    /**
+     * Uploads an already-gzipped file without recompression. For very large files.
+     */
+    public function uploadRaw(string $compressedPath): void {
+        $this->uploadBody(fopen($compressedPath, 'rb'));
+    }
+
+    /**
+     * @param string|resource $body
+     */
+    private function uploadBody($body): void {
+        if (($this->destination['encoding'] ?? null) !== 'gzip') {
+            throw new \RuntimeException('Unsupported destination encoding');
+        }
+        $statusCode = $this->getClient()->request('PUT', $this->destination['url'], [
+            'body' => $body,
+        ])->getStatusCode();
+        if ($statusCode !== 200) {
+            throw new \RuntimeException('Result upload failed: HTTP ' . $statusCode);
+        }
+    }
+
+    private function createTempFile(string $prefix): string {
+        $path = tempnam(sys_get_temp_dir(), $prefix);
+        if ($path === false) {
+            throw new \RuntimeException('Cannot create temporary file');
+        }
+
+        return $path;
+    }
+}

--- a/src/Event/Export/ExportFile.php
+++ b/src/Event/Export/ExportFile.php
@@ -36,13 +36,36 @@ class ExportFile {
         $compressedPath = $this->downloadRaw();
         $path = $this->createTempFile('export');
         $in = gzopen($compressedPath, 'rb');
-        $out = fopen($path, 'wb');
-        while (!gzeof($in)) {
-            fwrite($out, gzread($in, 512 * 1024));
+        if ($in === false) {
+            unlink($compressedPath);
+            unlink($path);
+            throw new \RuntimeException('Cannot open downloaded export');
         }
-        gzclose($in);
-        fclose($out);
-        unlink($compressedPath);
+        $out = fopen($path, 'wb');
+        if ($out === false) {
+            gzclose($in);
+            unlink($compressedPath);
+            unlink($path);
+            throw new \RuntimeException('Cannot open downloaded export');
+        }
+        $succeeded = false;
+        try {
+            while (!gzeof($in)) {
+                $chunk = gzread($in, 512 * 1024);
+                if ($chunk === false) {
+                    throw new \RuntimeException('Failed to decompress export');
+                }
+                fwrite($out, $chunk);
+            }
+            $succeeded = true;
+        } finally {
+            gzclose($in);
+            fclose($out);
+            unlink($compressedPath);
+            if (!$succeeded) {
+                unlink($path);
+            }
+        }
 
         return $path;
     }
@@ -89,7 +112,15 @@ class ExportFile {
      * Uploads an already-gzipped file without recompression. For very large files.
      */
     public function uploadRaw(string $compressedPath): void {
-        $this->uploadBody(fopen($compressedPath, 'rb'));
+        $handle = fopen($compressedPath, 'rb');
+        if ($handle === false) {
+            throw new \RuntimeException('Cannot open compressed export for upload');
+        }
+        try {
+            $this->uploadBody($handle);
+        } finally {
+            fclose($handle);
+        }
     }
 
     /**

--- a/src/Event/Export/ExportFile.php
+++ b/src/Event/Export/ExportFile.php
@@ -55,7 +55,9 @@ class ExportFile {
                 if ($chunk === false) {
                     throw new \RuntimeException('Failed to decompress export');
                 }
-                fwrite($out, $chunk);
+                if (fwrite($out, $chunk) === false) {
+                    throw new \RuntimeException('Failed to write temporary file');
+                }
             }
             $succeeded = true;
         } finally {
@@ -81,10 +83,24 @@ class ExportFile {
         $response = $client->request('GET', $this->source['url']);
         $path = $this->createTempFile('export-gz');
         $out = fopen($path, 'wb');
-        foreach ($client->stream($response) as $chunk) {
-            fwrite($out, $chunk->getContent());
+        if ($out === false) {
+            unlink($path);
+            throw new \RuntimeException('Cannot create temporary file');
         }
-        fclose($out);
+        $succeeded = false;
+        try {
+            foreach ($client->stream($response) as $chunk) {
+                if (fwrite($out, $chunk->getContent()) === false) {
+                    throw new \RuntimeException('Failed to write temporary file');
+                }
+            }
+            $succeeded = true;
+        } finally {
+            fclose($out);
+            if (!$succeeded) {
+                unlink($path);
+            }
+        }
 
         return $path;
     }

--- a/src/Event/Export/ExportFile.php
+++ b/src/Event/Export/ExportFile.php
@@ -34,6 +34,10 @@ class ExportFile {
      */
     public function download(): string {
         $compressedPath = $this->downloadRaw();
+        if (file_get_contents($compressedPath, false, null, 0, 2) !== "\x1f\x8b") {
+            unlink($compressedPath);
+            throw new \RuntimeException('Downloaded export is not gzip-compressed');
+        }
         $path = $this->createTempFile('export');
         $in = gzopen($compressedPath, 'rb');
         if ($in === false) {
@@ -81,6 +85,10 @@ class ExportFile {
         }
         $client = $this->getClient();
         $response = $client->request('GET', $this->source['url']);
+        $statusCode = $response->getStatusCode();
+        if ($statusCode !== 200) {
+            throw new \RuntimeException('Source download failed: HTTP ' . $statusCode);
+        }
         $path = $this->createTempFile('export-gz');
         $out = fopen($path, 'wb');
         if ($out === false) {
@@ -128,12 +136,13 @@ class ExportFile {
      * Uploads an already-gzipped file without recompression. For very large files.
      */
     public function uploadRaw(string $compressedPath): void {
+        $size = filesize($compressedPath);
         $handle = fopen($compressedPath, 'rb');
-        if ($handle === false) {
+        if ($size === false || $handle === false) {
             throw new \RuntimeException('Cannot open compressed export for upload');
         }
         try {
-            $this->uploadBody($handle);
+            $this->uploadBody($handle, $size);
         } finally {
             fclose($handle);
         }
@@ -142,13 +151,17 @@ class ExportFile {
     /**
      * @param string|resource $body
      */
-    private function uploadBody($body): void {
+    private function uploadBody($body, ?int $contentLength = null): void {
         if (($this->destination['encoding'] ?? null) !== 'gzip') {
             throw new \RuntimeException('Unsupported destination encoding');
         }
-        $statusCode = $this->getClient()->request('PUT', $this->destination['url'], [
-            'body' => $body,
-        ])->getStatusCode();
+        $options = ['body' => $body];
+        if ($contentLength !== null) {
+            // S3 presigned PUTs reject chunked Transfer-Encoding; a resource body
+            // needs an explicit Content-Length to keep the request unchunked.
+            $options['headers'] = ['Content-Length' => (string) $contentLength];
+        }
+        $statusCode = $this->getClient()->request('PUT', $this->destination['url'], $options)->getStatusCode();
         if ($statusCode !== 200) {
             throw new \RuntimeException('Result upload failed: HTTP ' . $statusCode);
         }

--- a/src/Event/Export/ExportTransformEvent.php
+++ b/src/Event/Export/ExportTransformEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Simplia\Integration\Event\Export;
+
+use Simplia\Integration\Event\IntegrationEvent;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class ExportTransformEvent implements IntegrationEvent {
+    private ExportFile $file;
+
+    public function __construct(
+        private readonly string $target,
+        array $source,
+        array $destination,
+        private readonly array $context = [],
+    ) {
+        $this->file = new ExportFile($source, $destination);
+    }
+
+    public function getTarget(): string {
+        return $this->target;
+    }
+
+    public function getContext(): array {
+        return $this->context;
+    }
+
+    public function getFile(): ExportFile {
+        return $this->file;
+    }
+
+    public function setHttpClient(HttpClientInterface $client): void {
+        $this->file->setHttpClient($client);
+    }
+}

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -166,12 +166,18 @@ class Handler implements BrefHandler {
 
         foreach ($httpClient->getTracedRequests() as $request) {
             $segment = new HttpSegment();
-            $name = parse_url($request['url'], PHP_URL_HOST);
+            $url = $request['url'];
+            if (str_contains($url, 'X-Amz-')) {
+                // Presigned S3 URLs carry live signatures in the query string;
+                // keep them out of X-Ray traces (rendered in shop admin pages).
+                $url = explode('?', $url, 2)[0];
+            }
+            $name = parse_url($url, PHP_URL_HOST);
             if (strpos($request['url'], $apiPrefix) === 0) {
                 $name = 'API ' . $name;
             }
             $segment
-                ->setUrl($request['url'])
+                ->setUrl($url)
                 ->setMethod($request['method'])
                 ->setName($name)
                 ->setResponseCode($request['info']['http_code'])

--- a/src/Handler.php
+++ b/src/Handler.php
@@ -12,6 +12,7 @@ use Pkerrigan\Xray\Trace;
 use RuntimeException;
 use Simplia\Api\Api;
 use Simplia\Integration\Event\EventDecoder;
+use Simplia\Integration\Event\Export\ExportTransformEvent;
 use Simplia\Integration\Storage\FileStorage;
 use Simplia\Integration\Storage\KeyValueStorage;
 use Simplia\Integration\Storage\LocalFileStorage;
@@ -48,6 +49,9 @@ class Handler implements BrefHandler {
 
             $fn = $this->handler;
             $typedInput = EventDecoder::fromInput($event);
+            if ($typedInput instanceof ExportTransformEvent) {
+                $typedInput->setHttpClient($http);
+            }
             $response = $fn(new Context(
                 $http,
                 $api,

--- a/tests/EventDecoderTest.php
+++ b/tests/EventDecoderTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Simplia\Integration\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Simplia\Integration\Event\EventDecoder;
+use Simplia\Integration\Event\Export\ExportTransformEvent;
+
+class EventDecoderTest extends TestCase {
+    public function testDecodesExportTransform(): void {
+        $event = EventDecoder::fromInput([
+            'type' => 'export.transform',
+            'target' => 'pohoda-invoice',
+            'source' => ['url' => 'https://s3.example/source', 'encoding' => 'gzip'],
+            'destination' => ['url' => 'https://s3.example/result', 'encoding' => 'gzip'],
+            'context' => ['filename' => 'pohoda.xml'],
+        ]);
+
+        self::assertInstanceOf(ExportTransformEvent::class, $event);
+        self::assertSame('pohoda-invoice', $event->getTarget());
+        self::assertSame(['filename' => 'pohoda.xml'], $event->getContext());
+    }
+
+    public function testUnknownTypeReturnsNull(): void {
+        self::assertNull(EventDecoder::fromInput(['type' => 'does.not.exist']));
+    }
+}

--- a/tests/ExportFileTest.php
+++ b/tests/ExportFileTest.php
@@ -81,4 +81,43 @@ class ExportFileTest extends TestCase {
         $this->expectException(\RuntimeException::class);
         $this->file($client)->uploadContent('<x/>');
     }
+
+    public function testDownloadFailsOnHttpError(): void {
+        $client = new MockHttpClient(new MockResponse('<Error>AccessDenied</Error>', ['http_code' => 403]));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Source download failed: HTTP 403');
+        $this->file($client)->download();
+    }
+
+    public function testDownloadRejectsNonGzipBody(): void {
+        $client = new MockHttpClient(new MockResponse('<Error>plain, not gzip</Error>'));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('not gzip-compressed');
+        $this->file($client)->download();
+    }
+
+    public function testUploadRawSendsContentLength(): void {
+        $capturedOptions = null;
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$capturedOptions) {
+            $capturedOptions = $options;
+
+            return new MockResponse('');
+        });
+
+        $body = gzencode('<transformed/>');
+        $path = tempnam(sys_get_temp_dir(), 'test');
+        file_put_contents($path, $body);
+        $this->file($client)->uploadRaw($path);
+        unlink($path);
+
+        $contentLength = null;
+        foreach ($capturedOptions['headers'] as $header) {
+            if (stripos($header, 'content-length:') === 0) {
+                $contentLength = trim(substr($header, strlen('content-length:')));
+            }
+        }
+        self::assertSame((string) strlen($body), $contentLength);
+    }
 }

--- a/tests/ExportFileTest.php
+++ b/tests/ExportFileTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Simplia\Integration\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Simplia\Integration\Event\Export\ExportFile;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class ExportFileTest extends TestCase {
+    private function file(MockHttpClient $client): ExportFile {
+        return new ExportFile(
+            ['url' => 'https://s3.example/source', 'encoding' => 'gzip'],
+            ['url' => 'https://s3.example/result', 'encoding' => 'gzip'],
+            $client,
+        );
+    }
+
+    public function testDownloadDecompressesToLocalFile(): void {
+        $client = new MockHttpClient(new MockResponse(gzencode('<data/>')));
+
+        $path = $this->file($client)->download();
+
+        self::assertSame('<data/>', file_get_contents($path));
+        unlink($path);
+    }
+
+    public function testGetContent(): void {
+        $client = new MockHttpClient(new MockResponse(gzencode('<data/>')));
+
+        self::assertSame('<data/>', $this->file($client)->getContent());
+    }
+
+    public function testUploadContentGzipsBody(): void {
+        $requests = [];
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$requests) {
+            $requests[] = [$method, $url, $options['body']];
+
+            return new MockResponse('');
+        });
+
+        $this->file($client)->uploadContent('<transformed/>');
+
+        self::assertCount(1, $requests);
+        [$method, $url, $body] = $requests[0];
+        self::assertSame('PUT', $method);
+        self::assertSame('https://s3.example/result', $url);
+        self::assertSame('<transformed/>', gzdecode($body));
+    }
+
+    public function testUploadRoundTripThroughFile(): void {
+        $captured = null;
+        $client = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured) {
+            $captured = $options['body'];
+
+            return new MockResponse('');
+        });
+
+        $path = tempnam(sys_get_temp_dir(), 'test');
+        file_put_contents($path, '<transformed/>');
+        $this->file($client)->upload($path);
+        unlink($path);
+
+        self::assertSame('<transformed/>', gzdecode($captured));
+    }
+
+    public function testUnsupportedSourceEncodingThrows(): void {
+        $file = new ExportFile(
+            ['url' => 'https://s3.example/source', 'encoding' => 'zip'],
+            ['url' => 'https://s3.example/result', 'encoding' => 'gzip'],
+            new MockHttpClient(),
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $file->download();
+    }
+
+    public function testFailedUploadThrows(): void {
+        $client = new MockHttpClient(new MockResponse('', ['http_code' => 403]));
+
+        $this->expectException(\RuntimeException::class);
+        $this->file($client)->uploadContent('<x/>');
+    }
+}


### PR DESCRIPTION
Adds the export.transform event type so integrations can customize eshop-generated exports (Pohoda XML first, Money/feeds later). The eshop uploads the gzipped export to S3 and invokes the Lambda with presigned GET/PUT URLs; ExportFile keeps download/decompress/compress/upload in one place so an integration works with a plain local file. Also adds the <export-transform> manifest XSD element and first PHPUnit infra for this repo (8 tests).