### PR TITLE
feat: allow the money-invoice export-transform target

### DIFF
--- a/assets/manifest.xsd
+++ b/assets/manifest.xsd
@@ -69,6 +69,7 @@
                                         <xs:simpleType>
                                             <xs:restriction base="xs:string">
                                                 <xs:enumeration value="pohoda-invoice"/>
+                                                <xs:enumeration value="money-invoice"/>
                                             </xs:restriction>
                                         </xs:simpleType>
                                     </xs:attribute>


### PR DESCRIPTION
Integration repos validate manifest.xml against this schema in CI, so the enumeration decides what an integration is allowed to declare. The eshop now offers an export-transform target for the new Money S3 invoice export, which a manifest could not declare yet.